### PR TITLE
明示的シーケンスの場合のLengthが0の時の対応

### DIFF
--- a/src/readSequenceItem.js
+++ b/src/readSequenceItem.js
@@ -23,7 +23,7 @@ export default function readSequenceItem (byteStream) {
     dataOffset: byteStream.position
   };
 
-  if (element.tag !== 'xfffee000') {
+  if (element.tag !== 'xfffee000' && element.tag !== 'xfffee0dd') {
     throw `dicomParser.readSequenceItem: item tag (FFFE,E000) not found at offset ${byteStream.position}`;
   }
 


### PR DESCRIPTION
- Explicit VRのケースにおいて、シーケンスの長さが明示的になっていたケースにおいて、長さが0の場合、終了コード（0xfffee0dd）が入るケースがあるが、従来のコードだと0xffee00（開始コード）がないと、Exceptionになっていたため、条件を追加。